### PR TITLE
fix: widen compatibility for Nuxt 3.x, bump to v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.0.1 (2026-02-20)
+
+### Fixes
+
+- Widen `@nuxt/kit` dependency range to `^3.7.0 || ^4.0.0` for Nuxt 3.x compatibility
+- Update module compatibility declaration to `^3.7.0 || ^4.0.0`
+- Add `continue-on-error` to release workflow npm publish step
+
 ## v1.0.0 (2026-02-19)
 
 Initial stable release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-actions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Type-safe server actions for Nuxt with Standard Schema validation (Zod, Valibot, ArkType), middleware, builder pattern, optimistic updates, SSR queries, streaming, and retry/dedupe",
   "repository": {
     "type": "git",
@@ -66,7 +66,7 @@
     "docs:preview": "vitepress preview docs"
   },
   "dependencies": {
-    "@nuxt/kit": "^4.3.1"
+    "@nuxt/kit": "^3.7.0 || ^4.0.0"
   },
   "peerDependencies": {
     "arktype": ">=2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@nuxt/kit':
-        specifier: ^4.3.1
+        specifier: ^3.7.0 || ^4.0.0
         version: 4.3.1(magicast@0.5.2)
     devDependencies:
       '@nuxt/devtools':

--- a/src/module.ts
+++ b/src/module.ts
@@ -205,7 +205,7 @@ export default defineNuxtModule<ModuleOptions>({
     name: 'nuxt-actions',
     configKey: 'actions',
     compatibility: {
-      nuxt: '>=3.7.0',
+      nuxt: '^3.7.0 || ^4.0.0',
     },
   },
   defaults: {


### PR DESCRIPTION
## Summary
- Widen `@nuxt/kit` dependency from `^4.3.1` to `^3.7.0 || ^4.0.0` so Nuxt 3.x users can install without version conflicts
- Update module `compatibility` declaration to `^3.7.0 || ^4.0.0` (matching pinia, color-mode format)
- Bump version to `1.0.1`
- Update CHANGELOG

## Context
Preparing for Nuxt Modules directory submission. The previous `@nuxt/kit: ^4.3.1` would force Nuxt 3.x users to install kit v4 alongside their kit v3, causing version mismatches.