### PR TITLE
ci: switch to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -21,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org/
 
@@ -40,11 +41,11 @@ jobs:
       - name: Build
         run: pnpm run prepack
 
+      - name: Update npm for OIDC support
+        run: npm install -g npm@latest
+
       - name: Publish to npm
-        run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        continue-on-error: true
+        run: npm publish --provenance --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Widen `@nuxt/kit` dependency range to `^3.7.0 || ^4.0.0` for Nuxt 3.x compatibility
 - Update module compatibility declaration to `^3.7.0 || ^4.0.0`
-- Add `continue-on-error` to release workflow npm publish step
+- Switch release workflow to OIDC trusted publishing (no token rotation needed)
 
 ## v1.0.0 (2026-02-19)
 


### PR DESCRIPTION
## Summary

- Replace token-based npm auth with OIDC trusted publishing
- Add `id-token: write` permission for OIDC token generation
- Use `npm publish --provenance` instead of `pnpm publish` (pnpm doesn't support OIDC yet)
- Install npm@latest for OIDC support (requires npm >= 11.5.1)
- Remove `NPM_TOKEN` dependency — no more token rotation needed
- Bump Node to 22 in release workflow

## Prerequisite

Configure trusted publisher on npmjs.com:
- Package settings → Trusted Publisher → GitHub Actions
- Owner: `billymaulana`
- Repository: `nuxt-actions`
- Workflow: `release.yml`

## Test plan

- [ ] Configure trusted publisher on npmjs.com
- [ ] Merge this PR
- [ ] Re-tag v1.0.1 and push to trigger release workflow
- [ ] Verify v1.0.1 published on npm with provenance badge