### PR TITLE
fix: critical bugs — AbortSignal compat, error detection, CSRF docs

### DIFF
--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -4,20 +4,9 @@ Best practices for securing your server actions in production.
 
 ## CSRF Protection
 
-Server actions are executed via standard HTTP requests (`POST`, `GET`, etc.) to `/api/_actions/*` endpoints. Nuxt includes built-in CSRF protection for server routes, but you should verify your configuration:
+Server actions are executed via standard HTTP requests (`POST`, `GET`, etc.) to `/api/_actions/*` endpoints. Nuxt does **not** include built-in CSRF protection — you must implement it yourself or use a module like [`nuxt-security`](https://nuxt-security.vercel.app/).
 
-```ts
-// nuxt.config.ts
-export default defineNuxtConfig({
-  routeRules: {
-    '/api/_actions/**': {
-      // Nuxt's default security headers apply
-    },
-  },
-})
-```
-
-For additional CSRF protection, use a middleware that validates a custom header:
+To add CSRF protection, use an action middleware that validates the request origin:
 
 ```ts
 // server/actions/_middleware.ts — not auto-scanned (underscore prefix)


### PR DESCRIPTION
## Summary

- **AbortSignal.any() compatibility**: Replaced `AbortSignal.any()` + `AbortSignal.timeout()` with `setTimeout` + flag pattern for Safari <17.4 and Node <20.3 compatibility
- **Structural isActionError detection**: Plain objects with `code` + `message` + `statusCode` (no `stack`) are now recognized as intentional action errors without requiring `createActionError()`
- **CSRF documentation**: Corrected false claim that Nuxt has built-in CSRF protection — it does not

## Test plan

- [x] All 383 unit tests pass (11 test files)
- [x] 4 new tests added (timeout via AbortError, structural detection, statusCode requirement, stack exclusion)
- [x] Lint passes
- [x] Build succeeds
- [ ] CI pipeline (lint, typecheck, test Node 20 & 22, build)