### PR TITLE
chore: release v1.0.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - dependencies
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     labels:
       - ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.0.2 (2026-02-20)
+
+### Fixes
+
+- Replace `AbortSignal.any()` with setTimeout+flag for Safari <17.4 / Node <20.3 compatibility
+- Add structural `isActionError` detection for plain error objects (code+message+statusCode)
+- Correct false CSRF protection claim in security docs
+- Disable Dependabot auto-PRs (keep security alerts only)
+
 ## v1.0.1 (2026-02-20)
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-actions",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Type-safe server actions for Nuxt with Standard Schema validation (Zod, Valibot, ArkType), middleware, builder pattern, optimistic updates, SSR queries, streaming, and retry/dedupe",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Bump version to 1.0.2
- Update CHANGELOG with v1.0.2 fixes
- Disable Dependabot auto-PRs (keep security alerts)

## Changes included in v1.0.2

- AbortSignal.any() compatibility fix (Safari <17.4, Node <20.3)
- Structural isActionError detection for plain error objects
- CSRF documentation correction
- 4 new edge-case tests (383 total)